### PR TITLE
Chore/python3

### DIFF
--- a/excel_handler/__init__.py
+++ b/excel_handler/__init__.py
@@ -1,4 +1,5 @@
-from handler import ExcelHandler
+from __future__ import absolute_import
+from .handler import ExcelHandler
 assert ExcelHandler
 
 version = "0.2.3"

--- a/excel_handler/fields.py
+++ b/excel_handler/fields.py
@@ -1,3 +1,6 @@
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 import xlrd
 import datetime
 
@@ -46,16 +49,16 @@ class Field(object):
             except:
                 try:
                     return self.choices_inv[value]
-                except ValueError, error:
+                except ValueError as error:
                     error.args += (self.name,)
                     raise ValueError(error)
-                except KeyError, error:
+                except KeyError as error:
                     error.args += (self.name,)
                     raise KeyError(error)
 
         try:
             return self.cast_method(value)
-        except ValueError, error:
+        except ValueError as error:
             error.args += (self.name, value)
             raise ValueError(error)
 
@@ -69,12 +72,12 @@ class Field(object):
         if self.choices:
             try:
                 value = self.choices[value]
-            except KeyError, error:
+            except KeyError as error:
                 if value is not None:
                     raise KeyError(error)
 
         if hasattr(value, 'translate'):
-            value = unicode(value)
+            value = str(value)
 
         sheet.write(row, self.col,  value)
 
@@ -104,7 +107,7 @@ class BooleanField(Field):
 class CharField(Field):
     def __init__(self, col, *args, **kwargs):
         super(CharField, self).__init__(col, *args, **kwargs)
-        self.cast_method = unicode
+        self.cast_method = str
 
 
 class DateTimeField(Field):

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,12 @@ setup(
         # 'mimeparse',
         'xlutils(>=1.6.0)',
         'XlsxWriter(>=0.5.7)',
+        'future(>=0.18.2)',
     ],
     install_requires=[
         'xlutils >= 1.6.0',
         'XlsxWriter >= 0.5.7',
+        'future >=0.18.2',
     ],
     package_data={
     },

--- a/test/test.py
+++ b/test/test.py
@@ -1,3 +1,4 @@
+from builtins import object
 from excel_handler import ExcelHandler
 from excel_handler import fields
 
@@ -5,7 +6,7 @@ import unittest
 import datetime
 
 
-class Query:
+class Query(object):
     def values_list(*args, **kwargs):
         return [(
             'one', 1
@@ -16,13 +17,13 @@ class Query:
         )]
 
 
-class Meta:
+class Meta(object):
     object_name = 'model'
 
 
-class Model():
+class Model(object):
 
-    class Objects:
+    class Objects(object):
         def all(self):
             return Query()
 
@@ -128,10 +129,10 @@ class TestExcelHandlerCase(unittest.TestCase):
         self.assertEqual(len(second_row), 2)
         self.assertEqual(len(second_row[0]), 4)
 
-        for key, value in data[0].items():
+        for key, value in list(data[0].items()):
             self.assertEqual(first_row[0][key], value)
 
-        for key, value in data[1].items():
+        for key, value in list(data[1].items()):
             self.assertEqual(second_row[0][key], value)
 
     def test_write_rows(self):
@@ -160,7 +161,7 @@ class TestErrorHandler(unittest.TestCase):
 
         self.assertEqual(len(expected_data), len(data))
         for i, obj in enumerate(expected_data):
-            for k, expected_value in obj.items():
+            for k, expected_value in list(obj.items()):
                 read_value = data[i][k]
                 self.assertEqual(read_value, expected_value)
 
@@ -185,7 +186,7 @@ class TestEmptyRows(unittest.TestCase):
 
         self.assertEqual(len(expected_data), len(data))
         for i, obj in enumerate(expected_data):
-            for k, expected_value in obj.items():
+            for k, expected_value in list(obj.items()):
                 read_value = data[i][k]
                 self.assertEqual(read_value, expected_value)
 
@@ -207,7 +208,7 @@ class TestEmptyRows(unittest.TestCase):
 
         self.assertEqual(len(expected_data), len(data))
         for i, obj in enumerate(expected_data):
-            for k, expected_value in obj.items():
+            for k, expected_value in list(obj.items()):
                 read_value = data[i][k]
                 self.assertEqual(read_value, expected_value)
 
@@ -252,7 +253,7 @@ class TestCustomExcelHandler(unittest.TestCase):
 
         self.assertEqual(len(expected_data), len(data))
         for i, obj in enumerate(expected_data):
-            for k, expected_value in obj.items():
+            for k, expected_value in list(obj.items()):
                 read_value = data[i][k]
                 self.assertEqual(read_value, expected_value)
 
@@ -290,7 +291,7 @@ class TestCustomExcelHandler(unittest.TestCase):
         self.assertEqual(len(in_data), 3)
 
         for i, obj in enumerate(data):
-            for k, v in obj.items():
+            for k, v in list(obj.items()):
                 self.assertEqual(in_data[i][k], v)
 
         # testing the choices valus
@@ -339,7 +340,7 @@ class TestForeignKeyField(unittest.TestCase):
 
         self.assertEqual(len(expected_data), len(data))
         for i, obj in enumerate(expected_data):
-            for k, expected_value in obj.items():
+            for k, expected_value in list(obj.items()):
                 read_value = data[i][k]
                 self.assertEqual(read_value, expected_value)
 


### PR DESCRIPTION
Make it python 2 & python 3 compatible

`TypeError: string argument expected, got 'bytes'` can be fixed with replacing `StringIO` with `BytesIO` from the `io` library
`-    excel_file = StringIO.StringIO()
+    excel_file = io.BytesIO()`